### PR TITLE
Avoid writing trailing comma to clang compilation database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## 1.0.6
+
+**2017-10-01**
+
+* Fixes
+	* Avoids writing a trailing comma to the clang compilation database ([issue #10](https://github.com/CoatiSoftware/vs-sourcetrail/issues/10)).
+
+
 ## 1.0.5
 
 **2017-09-27**

--- a/SourcetrailExtension/source.extension.vsixmanifest
+++ b/SourcetrailExtension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="acf15780-03b5-440e-a41e-db79b7043fc2" Version="1.0.5" Language="en-US" Publisher="Coati Software" />
+        <Identity Id="acf15780-03b5-440e-a41e-db79b7043fc2" Version="1.0.6" Language="en-US" Publisher="Coati Software" />
         <DisplayName>Sourcetrail Extension</DisplayName>
         <Description xml:space="preserve">This extension allows Visual Studio to communicate with Sourcetrail, a Clang based source code exploration tool. Additionally it can generate a Clang Compilation Database for any Visual Studio solution which can be used to run various Clang based tools.</Description>
         <MoreInfo>https://www.sourcetrail.com/</MoreInfo>

--- a/SourcetrailExtensionTests/IntegrationTests/CreateCdbTests.cs
+++ b/SourcetrailExtensionTests/IntegrationTests/CreateCdbTests.cs
@@ -226,7 +226,7 @@ namespace CoatiSoftware.SourcetrailExtension.IntegrationTests
 				SolutionParser.SolutionParser solutionParser = new SolutionParser.SolutionParser(new TestPathResolver());
 				solutionParser.CreateCompileCommands(
 					project, configurationNames[0], platformNames[0], "c11",
-					(CompileCommand command) => {
+					(CompileCommand command, bool lastFile) => {
 						cdb.AddCompileCommand(command);
 					}
 				);


### PR DESCRIPTION
Use multithreaded processing for all but the final project, and then
process that by itself so we can avoid writing a trailing comma after its
last file.

Fixes #10