### PR TITLE
Minor changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+end_of_line = crlf
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Set default behavior to automatically normalize line endings.
+* text eol=crlf
+
+# Binary files
+*.[Dd][Ll][Ll] binary
+*.[Ii][Cc][Oo] binary
+*.[Pp][Nn][Gg] binary
+*.[Ss][Nn][Kk] binary
+

--- a/SourcetrailExtension.sln
+++ b/SourcetrailExtension.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.8
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourcetrailExtension", "SourcetrailExtension\SourcetrailExtension.csproj", "{A585A530-E120-4C74-934E-D57ED12A7DA9}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -31,6 +31,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourcetrailExtensionUtility
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7298A53A-50A0-404A-B0C8-B408FE8AF2FB}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		CHANGELOG.md = CHANGELOG.md
 		IntegrationTests.testsettings = IntegrationTests.testsettings
@@ -39,9 +40,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Global
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -89,6 +87,9 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4C66C5F5-3EEA-4610-9459-83265475F9BF}
+	EndGlobalSection
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
 	EndGlobalSection
 	GlobalSection(Performance) = preSolution
 		HasPerformanceSessions = true

--- a/SourcetrailExtension/SolutionParser/CompilationDatabase.cs
+++ b/SourcetrailExtension/SolutionParser/CompilationDatabase.cs
@@ -137,5 +137,26 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 		{
 			_compileCommands.Clear();
 		}
+
+		public override bool Equals(object obj)
+		{
+			var database = obj as CompilationDatabase;
+			if (ReferenceEquals(this, database))
+			{
+				return true;
+			}
+
+			return database != null &&
+				   EqualityComparer<List<CompileCommand>>.Default.Equals(_compileCommands, database._compileCommands) &&
+				   CompileCommandCount == database.CompileCommandCount;
+		}
+
+		public override int GetHashCode()
+		{
+			var hashCode = 548601099;
+			hashCode = hashCode * -1521134295 + EqualityComparer<List<CompileCommand>>.Default.GetHashCode(_compileCommands);
+			hashCode = hashCode * -1521134295 + CompileCommandCount.GetHashCode();
+			return hashCode;
+		}
 	}
 }

--- a/SourcetrailExtension/SolutionParser/CompileCommand.cs
+++ b/SourcetrailExtension/SolutionParser/CompileCommand.cs
@@ -15,6 +15,7 @@
  */
 
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 {
@@ -95,6 +96,29 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 				command = JsonConvert.DeserializeObject<CompileCommand>(serialized);
 			}
 			return command;
+		}
+
+		public override bool Equals(object obj)
+		{
+			var command = obj as CompileCommand;
+			if (ReferenceEquals(this, command))
+			{
+				return true;
+			}
+
+			return command != null &&
+				   Directory == command.Directory &&
+				   Command == command.Command &&
+				   File == command.File;
+		}
+
+		public override int GetHashCode()
+		{
+			var hashCode = -1659665107;
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Directory);
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Command);
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(File);
+			return hashCode;
 		}
 	}
 }

--- a/SourcetrailExtension/SourcetrailExtension.csproj
+++ b/SourcetrailExtension/SourcetrailExtension.csproj
@@ -27,6 +27,12 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Default debug settings -->
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/SourcetrailExtensionTests/data/TestProjectSettings.props
+++ b/SourcetrailExtensionTests/data/TestProjectSettings.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <!-- Override system include directories so they're consistent in different environments-->
+        <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    </PropertyGroup>
+</Project>

--- a/SourcetrailExtensionTests/data/all_in_same_folder/test.vcxproj
+++ b/SourcetrailExtensionTests/data/all_in_same_folder/test.vcxproj
@@ -38,6 +38,7 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>

--- a/SourcetrailExtensionTests/data/cinder/ALL_BUILD.vcxproj
+++ b/SourcetrailExtensionTests/data/cinder/ALL_BUILD.vcxproj
@@ -54,6 +54,7 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>

--- a/SourcetrailExtensionTests/data/cinder/ZERO_CHECK.vcxproj
+++ b/SourcetrailExtensionTests/data/cinder/ZERO_CHECK.vcxproj
@@ -54,6 +54,7 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>

--- a/SourcetrailExtensionTests/data/cinder/cinder.vcxproj
+++ b/SourcetrailExtensionTests/data/cinder/cinder.vcxproj
@@ -54,6 +54,7 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>

--- a/SourcetrailExtensionTests/data/nmake_project_with_forced_include/nmake_project_with_forced_include.vcxproj
+++ b/SourcetrailExtensionTests/data/nmake_project_with_forced_include/nmake_project_with_forced_include.vcxproj
@@ -49,17 +49,9 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/SourcetrailExtensionTests/data/nmake_project_with_include_search_path/nmake_project_with_include_search_path.vcxproj
+++ b/SourcetrailExtensionTests/data/nmake_project_with_include_search_path/nmake_project_with_include_search_path.vcxproj
@@ -49,17 +49,9 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/SourcetrailExtensionTests/data/nmake_project_with_preprocessor_definition/nmake_project_with_preprocessor_definition.vcxproj
+++ b/SourcetrailExtensionTests/data/nmake_project_with_preprocessor_definition/nmake_project_with_preprocessor_definition.vcxproj
@@ -49,17 +49,9 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/SourcetrailExtensionTests/data/project_with_compile_as_default_option/project_with_compile_as_default_option.vcxproj
+++ b/SourcetrailExtensionTests/data/project_with_compile_as_default_option/project_with_compile_as_default_option.vcxproj
@@ -63,17 +63,9 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/SourcetrailExtensionTests/data/project_with_different_item_types/project_with_different_item_types.vcxproj
+++ b/SourcetrailExtensionTests/data/project_with_different_item_types/project_with_different_item_types.vcxproj
@@ -69,17 +69,9 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/SourcetrailExtensionTests/data/project_with_forced_include/project_with_forced_include.vcxproj
+++ b/SourcetrailExtensionTests/data/project_with_forced_include/project_with_forced_include.vcxproj
@@ -60,17 +60,9 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_noinherit_properties.vcxproj
+++ b/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_noinherit_properties.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_noinherit_properties.vcxproj
+++ b/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_noinherit_properties.vcxproj
@@ -57,23 +57,9 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="include_property_sheet.props" />
-    <Import Project="preprocessor_property_sheet.props" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="include_property_sheet.props" />
-    <Import Project="preprocessor_property_sheet.props" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="include_property_sheet.props" />
-    <Import Project="preprocessor_property_sheet.props" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
     <Import Project="include_property_sheet.props" />
     <Import Project="preprocessor_property_sheet.props" />
   </ImportGroup>

--- a/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_property_sheet_usage.json
+++ b/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_property_sheet_usage.json
@@ -1,12 +1,12 @@
 [
   {
     "directory": "<CompilationDatabaseFilePath>",
-    "command": "clang-tool -fms-extensions -fms-compatibility -fms-compatibility-version=19  -isystem \"<Macro $(ProjectDir)>include_folder_from_property_sheet\"  -isystem \"<Macro $(VC_IncludePath)>\"  -isystem \"<Macro $(WindowsSdk_71A_IncludePath)>\"  -D _DEBUG  -D _CONSOLE  -D PREPROCESSOR_DEFINITION_FROM_PROPERTY_SHEET  -D _USING_V110_SDK71_  -D _UNICODE  -D UNICODE -std=c++14  \"<ProjectBaseDirectory>/main.cpp\"",
+    "command": "clang-tool -fms-extensions -fms-compatibility -fms-compatibility-version=19  -isystem \"<Macro $(ProjectDir)>include_folder_from_property_sheet\"  -isystem \"<Macro $(VC_IncludePath)>\"  -isystem \"<Macro $(WindowsSDK_IncludePath)>\"  -D _DEBUG  -D _CONSOLE  -D PREPROCESSOR_DEFINITION_FROM_PROPERTY_SHEET  -D _UNICODE  -D UNICODE -std=c++14  \"<ProjectBaseDirectory>/main.cpp\"",
     "file": "<ProjectBaseDirectory>/main.cpp"
   },
   {
     "directory": "<CompilationDatabaseFilePath>",
-    "command": "clang-tool -fms-extensions -fms-compatibility -fms-compatibility-version=19  -isystem \"<Macro $(ProjectDir)>custom_include_folder\"  -isystem \"<Macro $(VC_IncludePath)>\"  -isystem \"<Macro $(WindowsSdk_71A_IncludePath)>\"  -D _DEBUG  -D _CONSOLE -std=c++14  \"<ProjectBaseDirectory>/main.cpp\"",
+    "command": "clang-tool -fms-extensions -fms-compatibility -fms-compatibility-version=19  -isystem \"<Macro $(ProjectDir)>custom_include_folder\"  -isystem \"<Macro $(VC_IncludePath)>\"  -isystem \"<Macro $(WindowsSDK_IncludePath)>\"  -D _DEBUG  -D _CONSOLE -std=c++14  \"<ProjectBaseDirectory>/main.cpp\"",
     "file": "<ProjectBaseDirectory>/main.cpp"
   }
 ]

--- a/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_property_sheet_usage.vcxproj
+++ b/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_property_sheet_usage.vcxproj
@@ -57,19 +57,8 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="include_property_sheet.props" />
-    <Import Project="preprocessor_property_sheet.props" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="include_property_sheet.props" />
-    <Import Project="preprocessor_property_sheet.props" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="include_property_sheet.props" />
-    <Import Project="preprocessor_property_sheet.props" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
     <Import Project="include_property_sheet.props" />
     <Import Project="preprocessor_property_sheet.props" />
   </ImportGroup>

--- a/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_property_sheet_usage.vcxproj
+++ b/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_property_sheet_usage.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/SourcetrailExtensionTests/data/solution_with_custom_named_project_configuration/solution_with_custom_named_project_configuration.vcxproj
+++ b/SourcetrailExtensionTests/data/solution_with_custom_named_project_configuration/solution_with_custom_named_project_configuration.vcxproj
@@ -38,11 +38,9 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='CustomConfiguration|Win32'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='CustomConfiguration|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), TestProjectSettings.props))\TestProjectSettings.props" Label="TestProjectSettings" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='CustomConfiguration|Win32'">


### PR DESCRIPTION
This includes minor changes:

- Add .gitattributes and .editorconfig to keep code consistent with what you expect. My default settings, for example, use spaces instead of tabs and unix line-endings, so I was constantly introducing those by accident. This seems to remedy that.
- Fix warnings about classes that defined `operator==()` but not `Equals(object)` and `GetHashCode()`.
- Remove *_xp platform toolset from test project -- If you don't have this component installed (I don't) the test won't load the project and will fail.
- Fix issues I was having with test output: My system include paths on my Win7 machine are different than what was expected, so the test projects use a property sheet to override them.