### PR TITLE
Fix incomplete project properties

### DIFF
--- a/SourcetrailExtensionTests/Helpers/TestPathResolver.cs
+++ b/SourcetrailExtensionTests/Helpers/TestPathResolver.cs
@@ -28,9 +28,17 @@ namespace CoatiSoftware.SourcetrailExtension.IntegrationTests.Helpers
 
 		public override string GetAsAbsoluteCanonicalPath(string path, IVCProjectWrapper project)
 		{
-			if (path.Length > 0 && !path.StartsWith("<") && !System.IO.Path.IsPathRooted(path))
+			if (path.Length > 0 && !path.StartsWith("<"))
 			{
-				path = "<ProjectBaseDirectory>/" + path;
+				if (!System.IO.Path.IsPathRooted(path))
+				{
+					path = "<ProjectBaseDirectory>/" + path;
+				}
+				else if (path.StartsWith(project.GetProjectDirectory(), System.StringComparison.CurrentCultureIgnoreCase))
+				{
+					// Work-around for paths Visual Studio already resolved for us
+					path = ResolveVsMacro("$(ProjectDir)", null) + path.Substring(project.GetProjectDirectory().Length);
+				}
 			}
 
 			return path;

--- a/SourcetrailExtensionTests/data/all_in_same_folder/test.vcxproj
+++ b/SourcetrailExtensionTests/data/all_in_same_folder/test.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -22,13 +22,13 @@
     <ProjectGuid>{03CDC311-12CE-4B5A-B1D6-DEE68194163D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>testtest</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/SourcetrailExtensionTests/data/project_with_property_sheet_usage/include_property_sheet.props
+++ b/SourcetrailExtensionTests/data/project_with_property_sheet_usage/include_property_sheet.props
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ImportGroup Label="PropertySheets" />
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)include_folder_from_property_sheet</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)include_folder_from_property_sheet;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ProjectDir)debug_include_folder_from_property_sheet;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
 </Project>

--- a/SourcetrailExtensionTests/data/project_with_property_sheet_usage/preprocessor_property_sheet.props
+++ b/SourcetrailExtensionTests/data/project_with_property_sheet_usage/preprocessor_property_sheet.props
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ImportGroup Label="PropertySheets" />
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>PREPROCESSOR_DEFINITION_FROM_PROPERTY_SHEET;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>DEBUG_PREPROCESSOR_DEFINITION_FROM_PROPERTY_SHEET;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
 </Project>

--- a/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_noinherit_properties.vcxproj
+++ b/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_noinherit_properties.vcxproj
@@ -81,7 +81,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;CUSTOM_PREPROCESSOR_DEFINITION</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)custom_include_folder</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;CUSTOM_PREPROCESSOR_DEFINITION</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)custom_include_folder</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -107,7 +107,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;CUSTOM_PREPROCESSOR_DEFINITION</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)custom_include_folder</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -123,7 +123,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;CUSTOM_PREPROCESSOR_DEFINITION</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)custom_include_folder</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_property_sheet_usage.json
+++ b/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_property_sheet_usage.json
@@ -1,12 +1,12 @@
 [
   {
     "directory": "<CompilationDatabaseFilePath>",
-    "command": "clang-tool -fms-extensions -fms-compatibility -fms-compatibility-version=19  -isystem \"<Macro $(ProjectDir)>include_folder_from_property_sheet\"  -isystem \"<Macro $(VC_IncludePath)>\"  -isystem \"<Macro $(WindowsSDK_IncludePath)>\"  -D _DEBUG  -D _CONSOLE  -D PREPROCESSOR_DEFINITION_FROM_PROPERTY_SHEET  -D _UNICODE  -D UNICODE -std=c++14  \"<ProjectBaseDirectory>/main.cpp\"",
+    "command": "clang-tool -fms-extensions -fms-compatibility -fms-compatibility-version=19  -isystem \"<Macro $(ProjectDir)>custom_include_folder\"  -isystem \"<Macro $(ProjectDir)>debug_include_folder_from_property_sheet\"  -isystem \"<Macro $(ProjectDir)>include_folder_from_property_sheet\"  -isystem \"<Macro $(VC_IncludePath)>\"  -isystem \"<Macro $(WindowsSDK_IncludePath)>\"  -D _DEBUG  -D _CONSOLE  -D CUSTOM_PREPROCESSOR_DEFINITION  -D DEBUG_PREPROCESSOR_DEFINITION_FROM_PROPERTY_SHEET  -D PREPROCESSOR_DEFINITION_FROM_PROPERTY_SHEET  -D _UNICODE  -D UNICODE -std=c++14  \"<ProjectBaseDirectory>/main.cpp\"",
     "file": "<ProjectBaseDirectory>/main.cpp"
   },
   {
     "directory": "<CompilationDatabaseFilePath>",
-    "command": "clang-tool -fms-extensions -fms-compatibility -fms-compatibility-version=19  -isystem \"<Macro $(ProjectDir)>custom_include_folder\"  -isystem \"<Macro $(VC_IncludePath)>\"  -isystem \"<Macro $(WindowsSDK_IncludePath)>\"  -D _DEBUG  -D _CONSOLE -std=c++14  \"<ProjectBaseDirectory>/main.cpp\"",
+    "command": "clang-tool -fms-extensions -fms-compatibility -fms-compatibility-version=19  -isystem \"<Macro $(ProjectDir)>custom_include_folder\"  -isystem \"<Macro $(VC_IncludePath)>\"  -isystem \"<Macro $(WindowsSDK_IncludePath)>\"  -D _DEBUG  -D _CONSOLE  -D CUSTOM_PREPROCESSOR_DEFINITION -std=c++14  \"<ProjectBaseDirectory>/main.cpp\"",
     "file": "<ProjectBaseDirectory>/main.cpp"
   }
 ]

--- a/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_property_sheet_usage.vcxproj
+++ b/SourcetrailExtensionTests/data/project_with_property_sheet_usage/project_with_property_sheet_usage.vcxproj
@@ -80,7 +80,8 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;CUSTOM_PREPROCESSOR_DEFINITION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)custom_include_folder;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -91,7 +92,8 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;CUSTOM_PREPROCESSOR_DEFINITION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)custom_include_folder;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -104,7 +106,8 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;CUSTOM_PREPROCESSOR_DEFINITION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)custom_include_folder;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -119,7 +122,8 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;CUSTOM_PREPROCESSOR_DEFINITION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)custom_include_folder;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/VCProjectEngineWrapper/VCCLCompilerToolWrapper.cs
+++ b/VCProjectEngineWrapper/VCCLCompilerToolWrapper.cs
@@ -31,6 +31,7 @@ namespace VCProjectEngineWrapper
 		: IVCCLCompilerToolWrapper
 	{
 		private VCCLCompilerTool _wrapped = null;
+		private IVCRulePropertyStorage _wrappedRules = null;
 
 		public
 #if (VS2012)
@@ -45,11 +46,12 @@ namespace VCProjectEngineWrapper
 			(object wrapped)
 		{
 			_wrapped = wrapped as VCCLCompilerTool;
+			_wrappedRules = wrapped as IVCRulePropertyStorage;
 		}
 
 		public bool isValid()
 		{
-			return (_wrapped != null);
+			return (_wrapped != null && _wrappedRules != null);
 		}
 
 		public string GetWrappedVersion()
@@ -79,17 +81,17 @@ namespace VCProjectEngineWrapper
 
 		public string[] GetAdditionalIncludeDirectories()
 		{
-			return _wrapped.AdditionalIncludeDirectories.Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("AdditionalIncludeDirectories").Split(';');
 		}
 
 		public string[] GetPreprocessorDefinitions()
 		{
-			return _wrapped.PreprocessorDefinitions.Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("PreprocessorDefinitions").Split(';');
 		}
 
-		public string GetForcedIncludeFiles()
+		public string[] GetForcedIncludeFiles()
 		{
-			return _wrapped.ForcedIncludeFiles;
+			return _wrappedRules.GetEvaluatedPropertyValue("ForcedIncludeFiles").Split(';');
 		}
 	}
 }

--- a/VCProjectEngineWrapper/VCNMakeToolWrapper.cs
+++ b/VCProjectEngineWrapper/VCNMakeToolWrapper.cs
@@ -22,34 +22,36 @@ namespace VCProjectEngineWrapper
 #if (VS2012)
 		VCNMakeToolWrapperVs2012
 #elif (VS2013)
-        VCNMakeToolWrapperVs2013
+		VCNMakeToolWrapperVs2013
 #elif (VS2015)
 		VCNMakeToolWrapperVs2015
 #elif (VS2017)
 		VCNMakeToolWrapperVs2017
 #endif
-        : IVCNMakeToolWrapper
+		: IVCNMakeToolWrapper
 	{
 		private VCNMakeTool _wrapped = null;
+		private IVCRulePropertyStorage _wrappedRules = null;
 
 		public
 #if (VS2012)
 			VCNMakeToolWrapperVs2012
 #elif (VS2013)
-            VCNMakeToolWrapperVs2013
+			VCNMakeToolWrapperVs2013
 #elif (VS2015)
 			VCNMakeToolWrapperVs2015
 #elif (VS2017)
 			VCNMakeToolWrapperVs2017
 #endif
-            (object wrapped)
+			(object wrapped)
 		{
 			_wrapped = wrapped as VCNMakeTool;
+			_wrappedRules = wrapped as IVCRulePropertyStorage;
 		}
 
 		public bool isValid()
 		{
-			return (_wrapped != null);
+			return (_wrapped != null && _wrappedRules != null);
 		}
 
 		public string GetWrappedVersion()
@@ -64,17 +66,17 @@ namespace VCProjectEngineWrapper
 
 		public string[] GetIncludeSearchPaths()
 		{
-			return _wrapped.IncludeSearchPath.Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("NMakeIncludeSearchPath").Split(';');
 		}
 
 		public string[] GetPreprocessorDefinitions()
 		{
-			return _wrapped.PreprocessorDefinitions.Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("NMakePreprocessorDefinitions").Split(';');
 		}
 
-		public string GetForcedIncludes()
+		public string[] GetForcedIncludes()
 		{
-			return _wrapped.ForcedIncludes;
+			return _wrappedRules.GetEvaluatedPropertyValue("NMakeForcedIncludes").Split(';');
 		}
 
 	}

--- a/VCProjectEngineWrapper/VCResourceCompilerToolWrapper.cs
+++ b/VCProjectEngineWrapper/VCResourceCompilerToolWrapper.cs
@@ -31,6 +31,7 @@ namespace VCProjectEngineWrapper
 		: IVCResourceCompilerToolWrapper
 	{
 		private VCResourceCompilerTool _wrapped = null;
+		private IVCRulePropertyStorage _wrappedRules = null;
 
 		public
 #if (VS2012)
@@ -45,11 +46,12 @@ namespace VCProjectEngineWrapper
 			(object wrapped)
 		{
 			_wrapped = wrapped as VCResourceCompilerTool;
+			_wrappedRules = wrapped as IVCRulePropertyStorage;
 		}
 
 		public bool isValid()
 		{
-			return (_wrapped != null);
+			return (_wrapped != null && _wrappedRules != null);
 		}
 
 		public string GetWrappedVersion()
@@ -59,12 +61,12 @@ namespace VCProjectEngineWrapper
 
 		public string[] GetAdditionalIncludeDirectories()
 		{
-			return _wrapped.AdditionalIncludeDirectories.Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("AdditionalIncludeDirectories").Split(';');
 		}
 
 		public string[] GetPreprocessorDefinitions()
 		{
-			return _wrapped.PreprocessorDefinitions.Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("PreprocessorDefinitions").Split(';');
 		}
 	}
 }

--- a/VCProjectEngineWrapperInterfaces/IVCCLCompilerToolWrapper.cs
+++ b/VCProjectEngineWrapperInterfaces/IVCCLCompilerToolWrapper.cs
@@ -27,6 +27,6 @@ namespace VCProjectEngineWrapper
 		string GetToolPath();
 		string[] GetAdditionalIncludeDirectories();
 		string[] GetPreprocessorDefinitions();
-		string GetForcedIncludeFiles();
+		string[] GetForcedIncludeFiles();
 	}
 }

--- a/VCProjectEngineWrapperInterfaces/IVCNMakeToolWrapper.cs
+++ b/VCProjectEngineWrapperInterfaces/IVCNMakeToolWrapper.cs
@@ -24,6 +24,6 @@ namespace VCProjectEngineWrapper
 		string GetToolPath();
 		string[] GetIncludeSearchPaths();
 		string[] GetPreprocessorDefinitions();
-		string GetForcedIncludes();
+		string[] GetForcedIncludes();
 	}
 }


### PR DESCRIPTION
I found that in a certain case, I wasn't getting all of the preprocessor
definitions that were present:

In a property sheet:

```xml
<ItemDefinitionGroup>
  <ClCompile>
     <PreprocessorDefinitions>NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
  </ClCompile>
<ItemDefinitionGroup>
<ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
  <ClCompile>
    <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
  </ClCompile>
</ItemDefinitionGroup>
```

In a project including the property sheet:

```xml
<ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
  <ClCompile>
    <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
  </ClCompile>
</ItemDefinitionGroup>
```

In this case, I was missing `NOMINMAX`. I'm not sure why, but the
functionality that was being used to get these values just left it out.

The tool wrappers can each cast their wrapped objects to an
`IVCRulePropertyStorage`, which does return the correct information. It also
handles property sheets and everything else, so it should simplify the
code a lot.

Fixes #12