### PR TITLE
Add additional clang options setting for CDB creation

### DIFF
--- a/SourcetrailExtension/SolutionParser/CompilationDatabaseSettings.cs
+++ b/SourcetrailExtension/SolutionParser/CompilationDatabaseSettings.cs
@@ -32,6 +32,8 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 		private string _configurationName = "";
 		private string _platformName = "";
 
+		private string _additionalClangOptions = "";
+
 		public string Name
 		{
 			get { return _name; }
@@ -72,6 +74,12 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 		{
 			get { return _platformName; }
 			set { _platformName = value; }
+		}
+
+		public string AdditionalClangOptions
+		{
+			get { return _additionalClangOptions; }
+			set { _additionalClangOptions = value; }
 		}
 
 		public bool CheckCdbExists()
@@ -129,6 +137,9 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 			XmlElement platform = doc.CreateElement("platform");
 			platform.InnerText = _platformName;
 
+			XmlElement additionalClangOptions = doc.CreateElement("additionalClangOptions");
+			additionalClangOptions.InnerText = _additionalClangOptions;
+
 			root.AppendChild(name);
 			root.AppendChild(sourceProject);
 			root.AppendChild(directory);
@@ -136,6 +147,7 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 			root.AppendChild(includedProjects);
 			root.AppendChild(configuration);
 			root.AppendChild(platform);
+			root.AppendChild(additionalClangOptions);
 
 			return root;
 		}
@@ -209,8 +221,11 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 			XmlNode platformNode = node.SelectSingleNode("platform");
 			string platform = platformNode.InnerText;
 
+			XmlNode additionalClangOptionsNode = node.SelectSingleNode("additionalClangOptions");
+			string additionalClangOptions = additionalClangOptionsNode.InnerText;
+
 			// if cdb file is not there anymore, set the modified date back so that a full update will be performed
-			if(System.IO.File.Exists(directory + "\\" + name + ".json") == false)
+			if (System.IO.File.Exists(directory + "\\" + name + ".json") == false)
 			{
 				updatedDate = System.DateTime.MinValue;
 			}
@@ -222,6 +237,7 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 			cdb.IncludedProjects = includedProjectsList;
 			cdb.ConfigurationName = configuration;
 			cdb.PlatformName = platform;
+			cdb.AdditionalClangOptions = additionalClangOptions;
 
 			return cdb;
 		}

--- a/SourcetrailExtension/SolutionParser/SolutionParser.cs
+++ b/SourcetrailExtension/SolutionParser/SolutionParser.cs
@@ -45,7 +45,7 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 			_pathResolver = pathResolver;
 		}
 
-		public void CreateCompileCommands(Project project, string solutionConfigurationName, string solutionPlatformName, string cStandard, Action<CompileCommand, bool> lambda)
+		public void CreateCompileCommands(Project project, string solutionConfigurationName, string solutionPlatformName, string cStandard, string additionalClangOptions, Action<CompileCommand, bool> lambda)
 		{
 			Logging.Logging.LogInfo("Creating command objects for project \"" + Logging.Obfuscation.NameObfuscator.GetObfuscatedName(project.Name) + "\".");
 
@@ -108,6 +108,11 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 
 					commandFlags += _compatibilityVersionFlag + " ";
 
+					if (!string.IsNullOrWhiteSpace(additionalClangOptions))
+					{
+						commandFlags += additionalClangOptions;
+					}
+
 					foreach (string dir in includeDirectories)
 					{
 						commandFlags += " -isystem \"" + dir + "\" "; // using '-isystem' because it allows for use of quotes and pointy brackets in source files. In other words it's more robust. It's slower than '-I' though
@@ -162,7 +167,7 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 
 				if (dte == null)
 				{
-					Logging.Logging.LogError("Failed to retreive DTE object. Abort creating command object.");
+					Logging.Logging.LogError("Failed to retrieve DTE object. Abort creating command object.");
 				}
 
 				IVCFileWrapper vcFile = VCFileWrapperFactory.create(item.Object);

--- a/SourcetrailExtension/SourcetrailExtensionPackage.cs
+++ b/SourcetrailExtension/SourcetrailExtensionPackage.cs
@@ -343,7 +343,7 @@ namespace CoatiSoftware.SourcetrailExtension
 			Utility.AsynchronousClient.Send(message);
 		}
 
-		private void OnCreateProject(List<EnvDTE.Project> projects, string configurationName, string platformName, string targetDir, string fileName, string cStandard)
+		private void OnCreateProject(List<EnvDTE.Project> projects, string configurationName, string platformName, string targetDir, string fileName, string cStandard, string additionalClangOptions)
 		{
 			DTE dte = (DTE)GetService(typeof(DTE));
 
@@ -356,6 +356,7 @@ namespace CoatiSoftware.SourcetrailExtension
 			createCdbWindow.CStandard = cStandard;
 			createCdbWindow.ThreadCount = (int)ThreadCount;
 			createCdbWindow.SolutionDir = Utility.SolutionUtility.GetSolutionPath(dte);
+			createCdbWindow.AdditionalClangOptions = additionalClangOptions;
 
 			createCdbWindow.Cdb = _recentSettingsList.GetCdbForSolution(createCdbWindow.SolutionDir, targetDir + "\\" + fileName + ".json");
 

--- a/SourcetrailExtension/Wizard/ProjectSetupWindow.Designer.cs
+++ b/SourcetrailExtension/Wizard/ProjectSetupWindow.Designer.cs
@@ -1,22 +1,22 @@
 ﻿namespace CoatiSoftware.SourcetrailExtension.Wizard
 {
-    partial class ProjectSetupWindow
-    {
-        private System.ComponentModel.IContainer components = null;
+	partial class ProjectSetupWindow
+	{
+		private System.ComponentModel.IContainer components = null;
 
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
 
-        #region Windows Form Designer generated code
+		#region Windows Form Designer generated code
 
-        private void InitializeComponent()
-        {
+		private void InitializeComponent()
+		{
 			this.components = new System.ComponentModel.Container();
 			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ProjectSetupWindow));
 			this.buttonCancel = new System.Windows.Forms.Button();
@@ -39,12 +39,14 @@
 			this.backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
 			this.labelCStandard = new System.Windows.Forms.Label();
 			this.treeViewProjects = new System.Windows.Forms.TreeView();
+			this.labelAdditionalClangOptions = new System.Windows.Forms.Label();
+			this.textBoxAdditionalClangOptions = new System.Windows.Forms.TextBox();
 			this.SuspendLayout();
 			// 
 			// buttonCancel
 			// 
 			this.helpProvider1.SetHelpString(this.buttonCancel, "Abort creation of the Compilation Database");
-			this.buttonCancel.Location = new System.Drawing.Point(12, 413);
+			this.buttonCancel.Location = new System.Drawing.Point(12, 441);
 			this.buttonCancel.Name = "buttonCancel";
 			this.helpProvider1.SetShowHelp(this.buttonCancel, true);
 			this.buttonCancel.Size = new System.Drawing.Size(92, 23);
@@ -57,7 +59,7 @@
 			// buttonCreate
 			// 
 			this.helpProvider1.SetHelpString(this.buttonCreate, "Start creation of the Compilation Database");
-			this.buttonCreate.Location = new System.Drawing.Point(178, 413);
+			this.buttonCreate.Location = new System.Drawing.Point(178, 441);
 			this.buttonCreate.Name = "buttonCreate";
 			this.helpProvider1.SetShowHelp(this.buttonCreate, true);
 			this.buttonCreate.Size = new System.Drawing.Size(92, 23);
@@ -73,28 +75,28 @@
 			this.comboBoxConfiguration.FormattingEnabled = true;
 			this.helpProvider1.SetHelpKeyword(this.comboBoxConfiguration, "Build configuration for Compilation Database");
 			this.helpProvider1.SetHelpString(this.comboBoxConfiguration, "The selected build configuration determines the compile flags for the Compilation" +
-        " Database");
+		" Database");
 			this.comboBoxConfiguration.Location = new System.Drawing.Point(87, 277);
 			this.comboBoxConfiguration.Name = "comboBoxConfiguration";
 			this.helpProvider1.SetShowHelp(this.comboBoxConfiguration, true);
 			this.comboBoxConfiguration.Size = new System.Drawing.Size(183, 21);
 			this.comboBoxConfiguration.TabIndex = 3;
 			this.toolTip1.SetToolTip(this.comboBoxConfiguration, "The selected build configuration determines the compile flags for the Compilation" +
-        " Database");
+		" Database");
 			// 
 			// comboBoxPlatform
 			// 
 			this.comboBoxPlatform.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.comboBoxPlatform.FormattingEnabled = true;
 			this.helpProvider1.SetHelpString(this.comboBoxPlatform, "The target platform determines some compiler flags included in the Compilation Da" +
-        "tabase");
+		"tabase");
 			this.comboBoxPlatform.Location = new System.Drawing.Point(87, 304);
 			this.comboBoxPlatform.Name = "comboBoxPlatform";
 			this.helpProvider1.SetShowHelp(this.comboBoxPlatform, true);
 			this.comboBoxPlatform.Size = new System.Drawing.Size(183, 21);
 			this.comboBoxPlatform.TabIndex = 4;
 			this.toolTip1.SetToolTip(this.comboBoxPlatform, "The target platform determines some compiler flags included in the Compilation Da" +
-        "tabase");
+		"tabase");
 			// 
 			// labelConfiguration
 			// 
@@ -192,14 +194,14 @@
 			this.comboBoxCStandard.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.comboBoxCStandard.FormattingEnabled = true;
 			this.helpProvider1.SetHelpString(this.comboBoxCStandard, "In case your solution contains C files, please specify which C standard is to be " +
-        "used for building.");
+		"used for building.");
 			this.comboBoxCStandard.Location = new System.Drawing.Point(87, 386);
 			this.comboBoxCStandard.Name = "comboBoxCStandard";
 			this.helpProvider1.SetShowHelp(this.comboBoxCStandard, true);
 			this.comboBoxCStandard.Size = new System.Drawing.Size(183, 21);
 			this.comboBoxCStandard.TabIndex = 7;
 			this.toolTip1.SetToolTip(this.comboBoxCStandard, "In case your solution contains C files, please specify which C standard is to be " +
-        "used for building.");
+		"used for building.");
 			// 
 			// labelCStandard
 			// 
@@ -220,12 +222,31 @@
 			this.treeViewProjects.AfterCheck += new System.Windows.Forms.TreeViewEventHandler(this.treeViewProjects_NodeCheckChanged);
 			this.treeViewProjects.MouseUp += new System.Windows.Forms.MouseEventHandler(this.ProjectCheckList_MouseUp);
 			// 
+			// labelAdditionalClangOptions
+			// 
+			this.labelAdditionalClangOptions.AutoSize = true;
+			this.labelAdditionalClangOptions.Location = new System.Drawing.Point(12, 416);
+			this.labelAdditionalClangOptions.Name = "labelAdditionalClangOptions";
+			this.labelAdditionalClangOptions.Size = new System.Drawing.Size(73, 13);
+			this.labelAdditionalClangOptions.TabIndex = 18;
+			this.labelAdditionalClangOptions.Text = "Clang Options";
+			// 
+			// textBoxAdditionalClangOptions
+			// 
+			this.textBoxAdditionalClangOptions.Location = new System.Drawing.Point(87, 413);
+			this.textBoxAdditionalClangOptions.Name = "textBoxAdditionalClangOptions";
+			this.textBoxAdditionalClangOptions.Size = new System.Drawing.Size(183, 20);
+			this.textBoxAdditionalClangOptions.TabIndex = 19;
+			this.textBoxAdditionalClangOptions.WordWrap = false;
+			// 
 			// ProjectSetupWindow
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.AutoSize = true;
-			this.ClientSize = new System.Drawing.Size(282, 443);
+			this.ClientSize = new System.Drawing.Size(282, 475);
+			this.Controls.Add(this.textBoxAdditionalClangOptions);
+			this.Controls.Add(this.labelAdditionalClangOptions);
 			this.Controls.Add(this.treeViewProjects);
 			this.Controls.Add(this.labelCStandard);
 			this.Controls.Add(this.comboBoxCStandard);
@@ -254,28 +275,30 @@
 			this.ResumeLayout(false);
 			this.PerformLayout();
 
-        }
+		}
 
-        #endregion
-        private System.Windows.Forms.Button buttonCancel;
-        private System.Windows.Forms.Button buttonCreate;
-        private System.Windows.Forms.ComboBox comboBoxConfiguration;
-        private System.Windows.Forms.ComboBox comboBoxPlatform;
-        private System.Windows.Forms.Label labelConfiguration;
-        private System.Windows.Forms.Label labelPlatform;
-        private System.Windows.Forms.Button buttonSelectAll;
-        private System.Windows.Forms.Label labelSelectProject;
-        private System.Windows.Forms.FolderBrowserDialog folderBrowserTargetDirectory;
-        private System.Windows.Forms.TextBox textBoxTargetDirectory;
-        private System.Windows.Forms.Button buttonSelect;
-        private System.Windows.Forms.TextBox textBoxFileName;
-        private System.Windows.Forms.Label labelFileName;
-        private System.Windows.Forms.Label labelFileNameExtension;
-        private System.Windows.Forms.HelpProvider helpProvider1;
-        private System.Windows.Forms.ToolTip toolTip1;
-        private System.ComponentModel.BackgroundWorker backgroundWorker1;
-        private System.Windows.Forms.ComboBox comboBoxCStandard;
-        private System.Windows.Forms.Label labelCStandard;
-        private System.Windows.Forms.TreeView treeViewProjects;
-    }
+		#endregion
+		private System.Windows.Forms.Button buttonCancel;
+		private System.Windows.Forms.Button buttonCreate;
+		private System.Windows.Forms.ComboBox comboBoxConfiguration;
+		private System.Windows.Forms.ComboBox comboBoxPlatform;
+		private System.Windows.Forms.Label labelConfiguration;
+		private System.Windows.Forms.Label labelPlatform;
+		private System.Windows.Forms.Button buttonSelectAll;
+		private System.Windows.Forms.Label labelSelectProject;
+		private System.Windows.Forms.FolderBrowserDialog folderBrowserTargetDirectory;
+		private System.Windows.Forms.TextBox textBoxTargetDirectory;
+		private System.Windows.Forms.Button buttonSelect;
+		private System.Windows.Forms.TextBox textBoxFileName;
+		private System.Windows.Forms.Label labelFileName;
+		private System.Windows.Forms.Label labelFileNameExtension;
+		private System.Windows.Forms.HelpProvider helpProvider1;
+		private System.Windows.Forms.ToolTip toolTip1;
+		private System.ComponentModel.BackgroundWorker backgroundWorker1;
+		private System.Windows.Forms.ComboBox comboBoxCStandard;
+		private System.Windows.Forms.Label labelCStandard;
+		private System.Windows.Forms.TreeView treeViewProjects;
+		private System.Windows.Forms.Label labelAdditionalClangOptions;
+		private System.Windows.Forms.TextBox textBoxAdditionalClangOptions;
+	}
 }

--- a/SourcetrailExtension/Wizard/ProjectSetupWindow.cs
+++ b/SourcetrailExtension/Wizard/ProjectSetupWindow.cs
@@ -36,7 +36,7 @@ namespace CoatiSoftware.SourcetrailExtension.Wizard
 			}
 		}
 
-		public delegate void OnCreateProject(List<EnvDTE.Project> projects, string configurationName, string platformName, string targetDir, string fileName, string cStandard);
+		public delegate void OnCreateProject(List<EnvDTE.Project> projects, string configurationName, string platformName, string targetDir, string fileName, string cStandard, string additionalClangOptions);
 
 		// public List<SolutionProject> m_projects = new List<SolutionProject>();
 		public Utility.SolutionUtility.SolutionStructure _projectStructure = new Utility.SolutionUtility.SolutionStructure();
@@ -76,6 +76,7 @@ namespace CoatiSoftware.SourcetrailExtension.Wizard
 			InitTextBoxTargetDirectory();
 			InitTextBoxFileName();
 			InitComboBoxCStandard();
+			InitTextBoxAdditionalClangOptions();
 		}
 
 		private void InitComboBoxConfigurations()
@@ -241,6 +242,20 @@ namespace CoatiSoftware.SourcetrailExtension.Wizard
 			}
 		}
 
+		private void InitTextBoxAdditionalClangOptions()
+		{
+			if (_cdb == null)
+			{
+				Logging.Logging.LogInfo("Setting additional clang options to default empty string");
+				textBoxAdditionalClangOptions.Text = "";
+			}
+			else
+			{
+				Logging.Logging.LogInfo("Setting additional clang options to recent: '" + _cdb.AdditionalClangOptions + "'");
+				textBoxAdditionalClangOptions.Text = _cdb.AdditionalClangOptions;
+			}
+		}
+
 		private void buttonCancel_Click(object sender, EventArgs e)
 		{
 			Logging.Logging.LogInfo("Close button pressed. Aborting.");
@@ -292,8 +307,12 @@ namespace CoatiSoftware.SourcetrailExtension.Wizard
 					}
 
 					Logging.Logging.LogInfo("Setting C standard flag to " + cStandard);
+					
+					string additionalClangOptions = textBoxAdditionalClangOptions.Text.Trim();
 
-					_onCreateProject(GetTreeViewProjectItems(), configurationName, platformName, targetDir, textBoxFileName.Text, cStandard);
+					Logging.Logging.LogInfo("Additional clang options: " + additionalClangOptions);
+
+					_onCreateProject(GetTreeViewProjectItems(), configurationName, platformName, targetDir, textBoxFileName.Text, cStandard, additionalClangOptions);
 					Close();
 				}
 				else

--- a/SourcetrailExtension/Wizard/WindowCreateCDB.cs
+++ b/SourcetrailExtension/Wizard/WindowCreateCDB.cs
@@ -46,6 +46,7 @@ namespace CoatiSoftware.SourcetrailExtension.Wizard
 		private string _fileName = "";
 		private string _cStandard = "";
 		private string _solutionDir = "";
+		private string _additionalClangOptions = "";
 
 		private SolutionParser.CompilationDatabaseSettings _cdb = null;
 
@@ -110,6 +111,12 @@ namespace CoatiSoftware.SourcetrailExtension.Wizard
 			set { _solutionDir = value; }
 		}
 
+		public string AdditionalClangOptions
+		{
+			get { return _additionalClangOptions; }
+			set { _additionalClangOptions = value; }
+		}
+
 		public SolutionParser.CompilationDatabaseSettings Cdb
 		{
 			get { return _cdb; }
@@ -160,6 +167,7 @@ namespace CoatiSoftware.SourcetrailExtension.Wizard
 				cdbSettings.LastUpdated = DateTime.Now;
 				cdbSettings.ConfigurationName = _configurationName;
 				cdbSettings.PlatformName = _platformName;
+				cdbSettings.AdditionalClangOptions = _additionalClangOptions;
 
 				cdbSettings.IncludedProjects = new List<string>();
 				foreach (EnvDTE.Project p in _projects)
@@ -188,7 +196,7 @@ namespace CoatiSoftware.SourcetrailExtension.Wizard
 				SolutionParser.SolutionParser solutionParser = new SolutionParser.SolutionParser(new VsPathResolver(_targetDir));
 
 				solutionParser.CreateCompileCommands(
-					project, _configurationName, _platformName, _cStandard,
+					project, _configurationName, _platformName, _cStandard, _additionalClangOptions,
 					(CompileCommand command, bool lastFile) => {
 						string serializedCommand = "";
 						foreach (string line in command.SerializeToJson().Split('\n'))

--- a/SourcetrailExtensionTests/IntegrationTests/CreateCdbTests.cs
+++ b/SourcetrailExtensionTests/IntegrationTests/CreateCdbTests.cs
@@ -225,7 +225,7 @@ namespace CoatiSoftware.SourcetrailExtension.IntegrationTests
 
 				SolutionParser.SolutionParser solutionParser = new SolutionParser.SolutionParser(new TestPathResolver());
 				solutionParser.CreateCompileCommands(
-					project, configurationNames[0], platformNames[0], "c11",
+					project, configurationNames[0], platformNames[0], "c11", null,
 					(CompileCommand command, bool lastFile) => {
 						cdb.AddCompileCommand(command);
 					}


### PR DESCRIPTION
I found I needed to add `-ferror-limit=0` to keep clang from bailing after too many errors (using clang-tidy, so I want to see all the errors!)

Baking it into the compilation database should be much easier than remembering to pass it to clang every time I run it.