### PR TITLE
Add "root = true" to top of .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,12 @@
+## Reference:
+#   - http://editorconfig.org/
+#   - https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options
+## Visual Studio IDE support for editing .editorconfig files:
+#   - https://marketplace.visualstudio.com/items?itemName=EditorConfigTeam.EditorConfig
+
+root = true
+
 [*]
 end_of_line = crlf
 indent_style = tab
+


### PR DESCRIPTION
This will keep your editor from continuing to look in parent directories.
For example, if you have a default .editorconfig file in `C:\Code\Repos\` it
will apply to all subdirectories in that folder that don't have root
`.editorconfig` files themselves.