### PR TITLE
Updated Readme with troubleshooting information

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Thanks to [Dakota Hawkins](https://github.com/dakotahawkins) for contributions.
 
 ## Troubleshooting
 
-The first step to troubleshooting is to enable logging for the extension. This can be found in the settings for SourceTrail in `Tools` -> `Options` -> `Sourcetrail`
+The first step to troubleshooting is to enable logging for the extension. This can be found in the settings for Sourcetrail in `Tools` -> `Options` -> `Sourcetrail`
 
 ### `Create Compilation Database` is greyed out
 Check that the loaded solution contains at least one C/C++ project in it. 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ We really appreciate every possible kind of contributions. Pull-requests are gre
 
 Thanks to [Dakota Hawkins](https://github.com/dakotahawkins) for contributions.
 
+## Troubleshooting
+
+The first step to troubleshooting is to enable logging for the extension. This can be found in the settings for SourceTrail in `Tools` -> `Options` -> `Sourcetrail`
+
+### `Create Compilation Database` is greyed out
+Check that the loaded solution contains at least one C/C++ project in it. 
+If logging is enabled for Sourcetrail, there may be messages in the output window resembling this one:
+
+`Error: Exception: The solution's source code database may not have been opened. Please make sure the solution is not open in another copy of Visual Studio, and that its database file is not read only.`
+
+This indicates that Intellisense or the browse database is disabled. Sourcetrail requires the browse database. It can be enabled in `Tools` -> `Options` -> `Text Editor` -> `C/C++` -> `Advanced`.
+
 ## Project Structure
 The `SourcetrailExtension` solution contains several different projects. This section should explain their purpose.
 


### PR DESCRIPTION
Sourcetrail may grey out the `Create Compilation Database` option if it fails
to find any C/C++ projects. It might fail to find said projects if Intellisense
is disabled. When Intellisense is disabled, DTE fails to get the Code Model
language for the project with a rather non-obvious error about the database
being read only.

The readme now contains this information

This fixes #27 