### PR TITLE
Fix ';'-delimited path parsing.

### DIFF
--- a/SourcetrailExtension/SolutionParser/SolutionParser.cs
+++ b/SourcetrailExtension/SolutionParser/SolutionParser.cs
@@ -386,7 +386,7 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 				IVCPlatformWrapper platform = vcProjectConfig.GetPlatform();
 
 				List<string> finalDirectories = new List<string>();
-				foreach (string directory in platform.GetExecutableDirectories().Split(';'))
+				foreach (string directory in platform.GetExecutableDirectories().SplitPaths())
 				{
 					IPathResolver resolver = new VsPathResolver("");
 					finalDirectories.AddRange(resolver.ResolveVsMacroInPath(directory, vcProjectConfig));

--- a/SourcetrailExtension/Utility/IPathResolver.cs
+++ b/SourcetrailExtension/Utility/IPathResolver.cs
@@ -56,7 +56,7 @@ namespace CoatiSoftware.SourcetrailExtension.Utility
 			}
 
 			List<string> pathList = new List<string>();
-			foreach (string resolvedPath in resolvedPaths.Split(';'))
+			foreach (string resolvedPath in resolvedPaths.SplitPaths())
 			{
 				pathList.Add(resolvedPath);
 			}

--- a/SourcetrailExtensionUtility/SourcetrailExtensionUtility.csproj
+++ b/SourcetrailExtensionUtility/SourcetrailExtensionUtility.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Logging\Obfuscation\NameObfuscator.cs" />
     <Compile Include="Logging\VSOutputLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StringExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Key.snk" />

--- a/SourcetrailExtensionUtility/StringExtensions.cs
+++ b/SourcetrailExtensionUtility/StringExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CoatiSoftware.SourcetrailExtension
+{
+	public static class StringExtensions
+	{
+		public static string[] SplitPaths(this string @this)
+		{
+			return @this.Split(';').Select(x => x.Trim()).ToArray();
+		}
+	}
+}

--- a/VCProjectEngineWrapper/VCCLCompilerToolWrapper.cs
+++ b/VCProjectEngineWrapper/VCCLCompilerToolWrapper.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using CoatiSoftware.SourcetrailExtension;
 using Microsoft.VisualStudio.VCProjectEngine;
 
 namespace VCProjectEngineWrapper
@@ -81,7 +82,7 @@ namespace VCProjectEngineWrapper
 
 		public string[] GetAdditionalIncludeDirectories()
 		{
-			return _wrappedRules.GetEvaluatedPropertyValue("AdditionalIncludeDirectories").Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("AdditionalIncludeDirectories").SplitPaths();
 		}
 
 		public string[] GetPreprocessorDefinitions()
@@ -103,12 +104,12 @@ namespace VCProjectEngineWrapper
 				break;
 			}
 
-			return (additionalDefines + _wrappedRules.GetEvaluatedPropertyValue("PreprocessorDefinitions")).Split(';');
+			return (additionalDefines + _wrappedRules.GetEvaluatedPropertyValue("PreprocessorDefinitions")).SplitPaths();
 		}
 
 		public string[] GetForcedIncludeFiles()
 		{
-			return _wrappedRules.GetEvaluatedPropertyValue("ForcedIncludeFiles").Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("ForcedIncludeFiles").SplitPaths();
 		}
 	}
 }

--- a/VCProjectEngineWrapper/VCNMakeToolWrapper.cs
+++ b/VCProjectEngineWrapper/VCNMakeToolWrapper.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using CoatiSoftware.SourcetrailExtension;
 using Microsoft.VisualStudio.VCProjectEngine;
 
 namespace VCProjectEngineWrapper
@@ -66,17 +67,17 @@ namespace VCProjectEngineWrapper
 
 		public string[] GetIncludeSearchPaths()
 		{
-			return _wrappedRules.GetEvaluatedPropertyValue("NMakeIncludeSearchPath").Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("NMakeIncludeSearchPath").SplitPaths();
 		}
 
 		public string[] GetPreprocessorDefinitions()
 		{
-			return _wrappedRules.GetEvaluatedPropertyValue("NMakePreprocessorDefinitions").Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("NMakePreprocessorDefinitions").SplitPaths();
 		}
 
 		public string[] GetForcedIncludes()
 		{
-			return _wrappedRules.GetEvaluatedPropertyValue("NMakeForcedIncludes").Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("NMakeForcedIncludes").SplitPaths();
 		}
 
 	}

--- a/VCProjectEngineWrapper/VCPlatformWrapper.cs
+++ b/VCProjectEngineWrapper/VCPlatformWrapper.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using CoatiSoftware.SourcetrailExtension;
 using Microsoft.VisualStudio.VCProjectEngine;
 
 namespace VCProjectEngineWrapper
@@ -64,7 +65,7 @@ namespace VCProjectEngineWrapper
 
 		public string[] GetIncludeDirectories()
 		{
-			return _wrapped.IncludeDirectories.Split(';');
+			return _wrapped.IncludeDirectories.SplitPaths();
 		}
 	}
 }

--- a/VCProjectEngineWrapper/VCResourceCompilerToolWrapper.cs
+++ b/VCProjectEngineWrapper/VCResourceCompilerToolWrapper.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using CoatiSoftware.SourcetrailExtension;
 using Microsoft.VisualStudio.VCProjectEngine;
 
 namespace VCProjectEngineWrapper 
@@ -61,12 +62,12 @@ namespace VCProjectEngineWrapper
 
 		public string[] GetAdditionalIncludeDirectories()
 		{
-			return _wrappedRules.GetEvaluatedPropertyValue("AdditionalIncludeDirectories").Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("AdditionalIncludeDirectories").SplitPaths();
 		}
 
 		public string[] GetPreprocessorDefinitions()
 		{
-			return _wrappedRules.GetEvaluatedPropertyValue("PreprocessorDefinitions").Split(';');
+			return _wrappedRules.GetEvaluatedPropertyValue("PreprocessorDefinitions").SplitPaths();
 		}
 	}
 }


### PR DESCRIPTION
Strip whitespace from each item after splitting on semicolon.  This fixes
exceptions raised due to CR/LF characters appearing in paths (which can be
introduced when project properties are provided via .props file).