### PR TITLE
excluded files will be discarded from compilation database

### DIFF
--- a/SourcetrailExtension/SolutionParser/SolutionParser.cs
+++ b/SourcetrailExtension/SolutionParser/SolutionParser.cs
@@ -192,6 +192,12 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 					{
 						if (vcFileConfiguration != null && vcFileConfiguration.isValid())
 						{
+							if (vcFileConfiguration.GetExcludedFromBuild())
+							{
+								Logging.Logging.LogInfo("Discarding item because it is excluded from build.");
+								return null;
+							}
+
 							compilerTool = vcFileConfiguration.GetCLCompilerTool();
 							if (compilerTool != null && compilerTool.isValid())
 							{
@@ -278,7 +284,7 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 		static private bool CheckIsSourceFile(ProjectItem item)
 		{
 			try
-			{
+			{				
 				string itemType = "";
 				if (ProjectUtility.HasProperty(item.Properties, "ItemType"))
 				{

--- a/VCProjectEngineWrapper/VCFileConfigurationWrapper.cs
+++ b/VCProjectEngineWrapper/VCFileConfigurationWrapper.cs
@@ -58,6 +58,11 @@ namespace VCProjectEngineWrapper
 			return Utility.GetWrappedVersion();
 		}
 
+		public bool GetExcludedFromBuild()
+		{
+			return _wrapped.ExcludedFromBuild;
+		}
+
 		public IVCCLCompilerToolWrapper GetCLCompilerTool()
 		{
 			object tool;

--- a/VCProjectEngineWrapperInterfaces/IVCFileConfigurationWrapper.cs
+++ b/VCProjectEngineWrapperInterfaces/IVCFileConfigurationWrapper.cs
@@ -21,6 +21,7 @@ namespace VCProjectEngineWrapper
 		string GetWrappedVersion();
 		bool isValid();
 
+		bool GetExcludedFromBuild();
 		IVCCLCompilerToolWrapper GetCLCompilerTool();
 	}
 }


### PR DESCRIPTION
Sourcetrail Extension will now consider the file level option "Excluded From Build" and prevent the respective files from being added to the generated compilation database.