### PR TITLE
Invalid path characters

### DIFF
--- a/SourcetrailExtension/SolutionParser/SolutionParser.cs
+++ b/SourcetrailExtension/SolutionParser/SolutionParser.cs
@@ -255,6 +255,9 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 					CompileCommand command = new CompileCommand();
 
 					string relativeFilePath = item.Properties.Item("RelativePath").Value.ToString();
+
+					relativeFilePath = relativeFilePath.Replace("\\\"", "");
+					relativeFilePath = relativeFilePath.Replace("\"", "");
 					command.File = _pathResolver.GetAsAbsoluteCanonicalPath(relativeFilePath, vcFile.GetProject());
 					command.File = command.File.Replace('\\', '/');
 

--- a/SourcetrailExtension/SolutionParser/VsPathResolver.cs
+++ b/SourcetrailExtension/SolutionParser/VsPathResolver.cs
@@ -16,6 +16,7 @@
 
 using CoatiSoftware.SourcetrailExtension.Utility;
 using System;
+using System.IO;
 using VCProjectEngineWrapper;
 
 namespace CoatiSoftware.SourcetrailExtension.SolutionParser
@@ -36,10 +37,18 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 
 		public override string GetAsAbsoluteCanonicalPath(string path, IVCProjectWrapper project)
 		{
-			if (path.Length > 0 && !System.IO.Path.IsPathRooted(path))
+			if (!string.IsNullOrEmpty(path))
 			{
-				path = project.GetProjectDirectory() + path;
-				path = new Uri(path).LocalPath;
+				if (path.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+				{
+					Logging.Logging.LogError("Path \"" + path + "\" contains invalid characters.");
+				}
+
+				if (!Path.IsPathRooted(path))
+				{
+					path = project.GetProjectDirectory() + path;
+					path = new Uri(path).LocalPath;
+				}
 			}
 			return path;
 		}

--- a/SourcetrailExtension/Utility/ProjectUtility.cs
+++ b/SourcetrailExtension/Utility/ProjectUtility.cs
@@ -129,6 +129,7 @@ namespace CoatiSoftware.SourcetrailExtension.Utility
 		{
 			return includeDirectories
 					.Select(x => x.Replace("\\\"", ""))
+					.Select(x => x.Replace("\"", ""))
 					.Select(x => pathResolver.GetAsAbsoluteCanonicalPath(x, project))
 					.Select(x => x.Replace("\\", "/")) // backslashes would cause some string-escaping hassles...
 					.Where(x => !string.IsNullOrWhiteSpace(x))


### PR DESCRIPTION
* add log message if file path provided for canonicalization contains invalid characters
* remove quotes that may surround the path of a detected include directory