### PR TITLE
Fix running out of memory when creating the compilation database

### DIFF
--- a/SourcetrailExtension/SolutionParser/SolutionParser.cs
+++ b/SourcetrailExtension/SolutionParser/SolutionParser.cs
@@ -45,7 +45,7 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 			_pathResolver = pathResolver;
 		}
 
-		public void CreateCompileCommands(Project project, string solutionConfigurationName, string solutionPlatformName, string cStandard, string additionalClangOptions, bool nonSystemIncludesUseAngleBrackets, Action<CompileCommand, bool> lambda)
+		public void CreateCompileCommands(Project project, string solutionConfigurationName, string solutionPlatformName, string cStandard, string additionalClangOptions, bool nonSystemIncludesUseAngleBrackets, Action<CompileCommand> lambda)
 		{
 			Logging.Logging.LogInfo("Creating command objects for project \"" + Logging.Obfuscation.NameObfuscator.GetObfuscatedName(project.Name) + "\".");
 
@@ -148,14 +148,14 @@ namespace CoatiSoftware.SourcetrailExtension.SolutionParser
 
 				// create command objects for all applicable project items
 				{
-					List<CompileCommand> compileCommands = Utility.ProjectUtility.GetProjectItems(project).Select(item =>
+					foreach (ProjectItem item in Utility.ProjectUtility.GetProjectItems(project))
 					{
-						return CreateCompileCommand(item, commandFlags, cppStandard, cStandard, isMakefileProject);
-					}).Where(command => command != null).ToList();
-
-					for (int i = 0; i < compileCommands.Count; i++)
-					{
-						lambda(compileCommands[i], i == compileCommands.Count - 1);
+						CompileCommand command = CreateCompileCommand(item, commandFlags, cppStandard, cStandard, isMakefileProject);
+						if (command == null)
+						{
+							continue;
+						}
+						lambda(command);
 					}
 				}
 

--- a/SourcetrailExtension/Wizard/WindowCreateCDB.cs
+++ b/SourcetrailExtension/Wizard/WindowCreateCDB.cs
@@ -205,7 +205,7 @@ namespace CoatiSoftware.SourcetrailExtension.Wizard
 
 				solutionParser.CreateCompileCommands(
 					project, _configurationName, _platformName, _cStandard, _additionalClangOptions, _nonSystemIncludesUseAngleBrackets,
-					(CompileCommand command, bool lastFile) => {
+					(CompileCommand command) => {
 						string serializedCommand = "";
 						foreach (string line in command.SerializeToJson().Split('\n'))
 						{
@@ -213,9 +213,14 @@ namespace CoatiSoftware.SourcetrailExtension.Wizard
 						}
 						serializedCommand = serializedCommand.TrimEnd('\n');
 
-						fileWriter.PushMessage(serializedCommand + (lastProject && lastFile ? "\n" : ",\n"));
+						fileWriter.PushMessage(serializedCommand + ",\n");
 					}
 				);
+
+				if (lastProject)
+				{
+					fileWriter.PushMessage("\n");
+				}
 
 				lock (_lockObject)
 				{

--- a/SourcetrailExtensionTests/IntegrationTests/CreateCdbTests.cs
+++ b/SourcetrailExtensionTests/IntegrationTests/CreateCdbTests.cs
@@ -244,7 +244,7 @@ namespace CoatiSoftware.SourcetrailExtension.Tests
 				SolutionParser.SolutionParser solutionParser = new SolutionParser.SolutionParser(new TestPathResolver());
 				solutionParser.CreateCompileCommands(
 					project, configurationNames[0], platformNames[0], "c11", null, nonSystemIncludesUseAngleBrackets,
-					(CompileCommand command, bool lastFile) =>
+					(CompileCommand command) =>
 					{
 						cdb.AddCompileCommand(command);
 					}


### PR DESCRIPTION
When I tried to use the extension against a larger project (Unreal Engine 4), I found that it was running out of memory (devenv.exe is 32 bit). Seems like an easy fix.